### PR TITLE
Ensure nil soa records aren't attached

### DIFF
--- a/db.go
+++ b/db.go
@@ -2,6 +2,7 @@ package mdns
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	_ "github.com/go-sql-driver/mysql"
@@ -87,6 +88,7 @@ func (mysql *MySQLDriver) getZone(zonename string) (Zone, error) {
 	       AND zones.deleted = '0'`, zonename)
 	err := row.StructScan(&zone)
 	if err != nil {
+		log.Error(fmt.Sprintf("Error fetching zone %s: %s", zonename, err))
 		return zone, err
 	}
 
@@ -209,6 +211,9 @@ func BuildDnsRRs(rrs []RR, zone Zone, axfr bool) ([]dns.RR, error) {
 
 	// Put the SOA record on first and last
 	if axfr == true {
+		if SoaRecord == nil {
+			return DnsRRs, errors.New("No SOA record found in AXFR")
+		}
 		DnsRRs = append(DnsRRs, SoaRecord)
 		DnsRRs = append([]dns.RR{SoaRecord}, DnsRRs...)
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -1,6 +1,7 @@
 package mdns_test
 
 import (
+	"database/sql"
 	"fmt"
 	"github.com/miekg/dns"
 	"testing"
@@ -79,4 +80,27 @@ func TestDBSOAQueryBadDB(t *testing.T) {
 
 	_, err := storage.Driver.GetQueryRRs("gomdns.com.", "SOA")
 	assert(t, err != nil, "There should have been an error")
+}
+
+func TestBuildDNSRRsNoSOA(t *testing.T) {
+	SetUp()
+
+	zone := mdns.Zone{Id: "foo.com.", Ttl: 300}
+	rrs := []mdns.RR{
+		mdns.RR{Id: "1", Rrtype: "A", Ttl: sql.NullInt64{Int64: 300, Valid: true}, Name: "bar.foo.com.", Data: "158.85.167.186", Action: "UPDATE", Created_at: "1"},
+	}
+
+	_, err := mdns.BuildDnsRRs(rrs, zone, true)
+	assert(t, err != nil, "There was no error!")
+}
+
+func TestBuildDNSRRsNoRRs(t *testing.T) {
+	SetUp()
+
+	zone := mdns.Zone{Id: "foo.com.", Ttl: 300}
+	rrs := []mdns.RR{}
+
+	dnsRRs, err := mdns.BuildDnsRRs(rrs, zone, true)
+	assert(t, dnsRRs == nil, fmt.Sprintf("DnsRRs wasn't []: %v", dnsRRs))
+	assert(t, err != nil, "There was no error!")
 }

--- a/mdns_handle.go
+++ b/mdns_handle.go
@@ -129,7 +129,9 @@ func handleAXFR(writer dns.ResponseWriter, request *dns.Msg, storage Storage) er
 }
 
 func sendAxfr(writer dns.ResponseWriter, request *dns.Msg, rrs []dns.RR) error {
+	zonename := request.Question[0].Name
 	envelopes := []dns.Envelope{}
+
 	SentRRs := 0
 	for SentRRs < len(rrs) {
 		RRsToSend := 100
@@ -144,7 +146,7 @@ func sendAxfr(writer dns.ResponseWriter, request *dns.Msg, rrs []dns.RR) error {
 		message := PrepReply(request)
 		message.Answer = append(message.Answer, envelope.RR...)
 		if err := writer.WriteMsg(message); err != nil {
-			log.Error(fmt.Sprintf("Error answering axfr: %s", err))
+			log.Error(fmt.Sprintf("Error answering axfr for %s: %s", zonename, err))
 			return err
 		}
 	}


### PR DESCRIPTION
- During some weird scenarios, an AXFR db query will get
RRs back, but no SOA record. If there is no soa record,
we were putting `nil` in, which was causing a panic because
of a nil reference. This ensure that can't happen anymore.