### PR TITLE
Add better benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,32 +51,10 @@ what you need to configure + the defaults.
 ## Is it Fast?
 
 Yes. Listening on localhost, with the same Designate database, here are some
-basic benchmarks against the current `designate-mdns`. These were created by
-sending 720 AXFRs/SOA Queries as fast as possible via `dig` in a BASH script:
+basic benchmarks against the current `designate-mdns`. These were created using
+the `bench` tool located in `/cmd`.
 
-```bash
-for i in `seq 1 40`;
-do
-    dig @localhost -p 5354 gomdns.com. -t AXFR +tcp &
-    dig @localhost -p 5354 testdomain44270094.com. -t AXFR +tcp &
-    dig @localhost -p 5354 testdomain84670112.com. -t AXFR +tcp &
-    ...
-done
-
-wait
-```
-
-### AXFR
-
-Keep in mind all of these were very small AXFRs (<10 records), the result
-size makes this almost an equal test to the SOA query test.
-
-`designate-mdns`: 30-60 AXFR/s `3919 ms` avg query time
-`mdns`: ~450 AXFR/s `121 ms` avg query time
-
-### SOA Queries
-
-`designate-mdns`: ~40 SOA queries/s `4996 ms` avg query time
-`mdns`: ~430 SOA queries/s `3.43 ms` avg query time
-
-
+|                | SOA Queries      | 2K Record AXFR |
+|----------------|------------------|----------------|
+| designate-mdns | 40 qps, ~1.2s    | 2.5 qps, ~2.3s |
+| mdns           | 2000 qps, ~.016s | 20 qps, ~.4s   |

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+var (
+	zones *string
+	qtype *string
+	num   *int
+)
+
+type Result struct {
+	Length int
+	Error  bool
+	Time   int64
+}
+
+func sendQuery(name string, ch chan Result) {
+	var length int
+
+	c := new(dns.Client)
+	c.DialTimeout = 15 * time.Second
+	c.ReadTimeout = 15 * time.Second
+	c.WriteTimeout = 15 * time.Second
+	question := new(dns.Msg)
+	question.SetQuestion(name, dns.TypeSOA)
+
+	start := time.Now()
+	msg, _, err := c.Exchange(question, "127.0.0.1:5354")
+	elapsed := int64(time.Since(start))
+	if err != nil {
+		log.Println(fmt.Sprintf("ERROR: Querying SOA for %s : %s", name, err))
+		length = 0
+	} else {
+		length = len(msg.Answer)
+	}
+
+	result := Result{Length: length, Error: err != nil, Time: elapsed}
+	ch <- result
+}
+
+func doAxfr(name string, ch chan Result) {
+	length := 0
+
+	t := new(dns.Transfer)
+	t.DialTimeout = 5 * time.Second
+	t.ReadTimeout = 5 * time.Second
+	t.WriteTimeout = 5 * time.Second
+	m := new(dns.Msg)
+	m.SetAxfr(name)
+	rrs := []dns.RR{}
+
+	start := time.Now()
+	transch, err := t.In(m, "127.0.0.1:5354")
+	for env := range transch {
+		rrs = append(rrs, env.RR...)
+	}
+	elapsed := int64(time.Since(start))
+	if err != nil {
+		log.Println(fmt.Sprintf("ERROR: AXFR for %s : %s", name, err))
+	} else {
+		length = len(rrs)
+	}
+	result := Result{Length: length, Error: err != nil, Time: elapsed}
+	ch <- result
+}
+
+func main() {
+	zones = flag.String("zones", "", "CSV list of zone names")
+	qtype = flag.String("qtype", "SOA", "Type of query to send {SOA, AXFR}")
+	num = flag.Int("queries", 10, "The number of queries to send for each zone")
+
+	flag.Parse()
+
+	log.Println(fmt.Sprintf("Finna %s %s %d times", *qtype, *zones, *num))
+
+	ch := make(chan Result)
+	results := []Result{}
+
+	start := time.Now()
+	for i := 0; i < *num; i++ {
+		if *qtype == "SOA" {
+			go sendQuery(*zones, ch)
+		} else if *qtype == "AXFR" {
+			go doAxfr(*zones, ch)
+		}
+	}
+
+	for i := 0; i < *num; i++ {
+		rez := <-ch
+		results = append(results, rez)
+	}
+	elapsed := time.Since(start)
+
+	totalTime := int64(elapsed / time.Millisecond)
+
+	numErrors := 0
+	totalLen := 0
+	cumTime := int64(0)
+	for _, r := range results {
+		if r.Error == true {
+			numErrors += 1
+		}
+		totalLen += r.Length
+		cumTime += r.Time / int64(time.Millisecond)
+	}
+	avgLen := float64(totalLen) / float64(*num)
+	avgTime := float64(cumTime) / float64(*num)
+
+	log.Println(fmt.Sprintf("Total execution time was %d ms", totalTime))
+	log.Println(fmt.Sprintf("Queries per second: %f", (float64(*num)/float64(totalTime))*1000))
+	log.Println(fmt.Sprintf("Total Errors: %d", numErrors))
+	log.Println(fmt.Sprintf("Avg Response Duration: %f ms", avgTime))
+	log.Println(fmt.Sprintf("Avg Response Length: %f rrs", avgLen))
+}

--- a/test_resources/customconfig.cnf
+++ b/test_resources/customconfig.cnf
@@ -1,2 +1,3 @@
 [mysqld]
 bind-address        = 0.0.0.0
+max_connections     = 10000


### PR DESCRIPTION
Create a lil tool to run some benchmarks
```
$ ./bench -qtype SOA -queries 1 -zones gomdns.com.
2016/04/26 18:21:57 Finna SOA gomdns.com. 1 times
2016/04/26 18:21:57 Total execution time was 1 ms
2016/04/26 18:21:57 Queries per second: 1000.000000
2016/04/26 18:21:57 Total Errors: 0
2016/04/26 18:21:57 Avg Response Duration: 1.000000 ms
2016/04/26 18:21:57 Avg Response Length: 1.000000 rrs

$  ./bench -qtype AXFR -queries 10 -zones testbigdomain28580535.com.
2016/04/26 18:26:54 Finna AXFR testbigdomain28580535.com. 10 times
2016/04/26 18:26:55 Total execution time was 509 ms
2016/04/26 18:26:55 Queries per second: 19.646365
2016/04/26 18:26:55 Total Errors: 0
2016/04/26 18:26:55 Avg Response Duration: 452.000000 ms
2016/04/26 18:26:55 Avg Response Length: 2004.000000 rrs
```