### PR TITLE
Add Makefile target to build with docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 MDNS_MYSQL_TAG=mdns-mysql
 MYSQL_CID=$(shell docker ps | grep "$(MDNS_MYSQL_TAG) " | cut -f1 -d' ')
+SOURCEDIR=.
+SOURCES := $(shell find $(SOURCEDIR) -path ./docker -prune -o -name '*.go')
+PKG_NAME=mdns
 
 help:
 		@echo ""
@@ -12,6 +15,9 @@ help:
 build: fmt
 		GO15VENDOREXPERIMENT=1 go build -o mdns -ldflags "-X main.builddate=`date -u '+%Y-%m-%d_%I:%M:%S%p'` -X main.gitref=`git rev-parse HEAD`" cmd/mdns.go
 
+build-docker: $(SOURCES)
+	docker run --rm -v `pwd`:/go/src/$(PKG_NAME) -w /go/src/$(PKG_NAME) golang:1.6 make build
+
 test-docker-build:
 		cd test_resources && docker build -t $(MDNS_MYSQL_TAG) -f mysql.Dockerfile .
 
@@ -23,8 +29,8 @@ test-docker-run:
 test-docker-kill%:
 		docker rm -f $(MYSQL_CID) || true
 
-test: test-docker-build test-docker-kill1 test-docker-run runtests test-docker-kill2 
-		
+test: test-docker-build test-docker-kill1 test-docker-run runtests test-docker-kill2
+
 runtests:
 		GO15VENDOREXPERIMENT=1 go test -v -coverprofile cover.out -bench=.
 		GO15VENDOREXPERIMENT=1 go tool cover -func=cover.out
@@ -37,4 +43,3 @@ fmt:
 
 clean: test-docker-kill1
 		rm -rf mdns
-


### PR DESCRIPTION
This is helpful for avoiding having to set up a go environment during
the build and doesn't require extra tooling like gb.